### PR TITLE
add disable option with the command-line mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,5 +126,13 @@ The plugin is disabled on GVim for Windows or MacVim, as GVim for Windows and
 MacVim already supports IM auto-switching. Set this variable to 1 if you want
 to enable anyway.
 
+### `g:im_select_enable_cmd_line`
+
+Set this variable to 0 if you want disable IM switching in the command-line
+mode. This setting is useful for users who wish to use a different input method
+(specifically for English characters) in the command-line mode, as opposed to
+the main text.
+default value is 1.
+
 <!-- vim: cc=79
 -->

--- a/plugin/im_select.vim
+++ b/plugin/im_select.vim
@@ -132,17 +132,23 @@ endif
 let g:ImSelectGetImCallback = get(g:, 'ImSelectGetImCallback', function('im_select#default_get_im_callback'))
 let g:im_select_switch_timeout = get(g:, 'im_select_switch_timeout', 50)
 let g:im_select_enable_focus_events = get(g:, 'im_select_enable_focus_events', 1)
+let g:im_select_enable_cmd_line = get(g:, 'im_select_enable_cmd_line', 1)
 
 let g:im_select_prev_im = ''
 
 function! im_select#enable() abort
     augroup im_select
         autocmd!
-        autocmd InsertEnter,CmdLineEnter * call im_select#on_insert_enter()
+        if g:im_select_enable_cmd_line
+            autocmd InsertEnter,CmdLineEnter * call im_select#on_insert_enter()
+            autocmd InsertLeave,CmdLineLeave * call im_select#on_insert_leave()
+        else
+            autocmd InsertEnter * call im_select#on_insert_enter()
+            autocmd InsertLeave * call im_select#on_insert_leave()
+        endif
         if exists('##TermEnter')
             autocmd TermEnter * call im_select#on_insert_enter()
         endif
-        autocmd InsertLeave,CmdLineLeave * call im_select#on_insert_leave()
         if exists('##TermLeave')
             autocmd TermLeave * call im_select#on_insert_leave()
         endif


### PR DESCRIPTION
Recently, the behavior of the plugin in command-line mode has been modified to switch input methods. I am aware that this change was prompted by the issue discussed here: https://github.com/brglng/vim-im-select/issues/11.

While this update appears to be beneficial for most users, it presents minor challenges for users like me, who are accustomed to using English characters in command-line mode, just as in normal mode. Typically, I use English for commands like `:w` and others while in command-line mode, rather than Japanese.

To address this, I have introduced an additional option: `g:im_select_enable_cmd_line`.

This new feature is designed to maintain the default behavior, ensuring that existing users experience no disruption.

I kindly request that you consider merging this update.